### PR TITLE
Ensure the pdf has been created before yielding to the block

### DIFF
--- a/lib/chromium/pdf.rb
+++ b/lib/chromium/pdf.rb
@@ -38,10 +38,15 @@ module Chromium
 
     def chrome_print(chrome_path, print_url, filename, filepath, arguments, &block)
       Kernel.system("LD_PRELOAD='' #{chrome_path} --print-to-pdf='#{filepath}' #{arguments.join(' ')} #{print_url}")
+      sleep 0.1 until file_created?(filepath)
 
       File.open(filepath) do |file|
         block&.call(file, filename)
       end
+    end
+
+    def file_created?(filepath)
+      File.exist?(filepath) && File.size(filepath).positive?
     end
   end
 end

--- a/test/jobs/test_generate_pdf_job.rb
+++ b/test/jobs/test_generate_pdf_job.rb
@@ -6,4 +6,8 @@ class TestGeneratePdfJob
   def perform(filename, url)
     generate_pdf!(filename, url)
   end
+
+  def file_created?(...)
+    true
+  end
 end


### PR DESCRIPTION
## Why?

It seems that sometimes the chrome process returns before the file has been written to disk. Check for the file to be written to before yielding to the block.

## What Changed

What changed in this PR?

* [x] Ensure pdf has been written before yielding

